### PR TITLE
Fix input loss during conversion and add fallback playback for macros without anchors

### DIFF
--- a/src/conversion/macro_converter.cpp
+++ b/src/conversion/macro_converter.cpp
@@ -478,7 +478,6 @@ static void finishImport(ImportedReplay& replay) {
 
     std::stable_sort(replay.inputs.begin(), replay.inputs.end(), inputLess);
 
-    std::array<bool, 6> held = { false, false, false, false, false, false };
     std::vector<ImportedInput> normalized;
     normalized.reserve(replay.inputs.size());
     size_t removedDuplicates = 0;
@@ -486,18 +485,24 @@ static void finishImport(ImportedReplay& replay) {
     for (auto input : replay.inputs) {
         input.button = sanitizeButton(input.button);
         input.tick = static_cast<int64_t>(std::llround(std::max(0.0, input.time * replay.fps)));
-        size_t idx = (input.player2 ? 3u : 0u) + static_cast<size_t>(input.button - 1);
-        if (held[idx] == input.pressed) {
-            ++removedDuplicates;
-            continue;
+
+        if (!normalized.empty()) {
+            auto const& last = normalized.back();
+            if (last.tick == input.tick &&
+                last.button == input.button &&
+                last.player2 == input.player2 &&
+                last.pressed == input.pressed) {
+                ++removedDuplicates;
+                continue;
+            }
         }
-        held[idx] = input.pressed;
+
         input.sequence = static_cast<uint64_t>(normalized.size());
         normalized.push_back(input);
     }
 
     if (removedDuplicates != 0) {
-        addWarningOnce(replay, "Removed duplicate or stale input transitions.");
+        addWarningOnce(replay, "Removed consecutive duplicate input transitions.");
     }
     replay.inputs = std::move(normalized);
 

--- a/src/core/replay_engine.cpp
+++ b/src/core/replay_engine.cpp
@@ -369,6 +369,38 @@ class $modify(MacroEngineBaseLayer, GJBaseGameLayer) {
         return player2 && keepSecondPlayerSlot(this);
     }
 
+    bool shouldUseInputOnlyTTRPlayback() {
+        auto* engine = ReplayEngine::get();
+
+        return engine &&
+            engine->engineMode == MODE_EXECUTE &&
+            engine->ttrMode &&
+            engine->activeTTR &&
+            !engine->activeTTR->inputs.empty() &&
+            engine->activeTTR->anchors.empty() &&
+            ReplayEngine::runtimeAccuracyModeFor(engine->activeTTR->accuracyMode) != AccuracyMode::CBS;
+    }
+
+    bool shouldUseInputOnlyGDRPlayback() {
+        auto* engine = ReplayEngine::get();
+        return engine &&
+            engine->engineMode == MODE_EXECUTE &&
+            !engine->ttrMode &&                     
+            engine->activeMacro &&
+            !engine->activeMacro->inputs.empty() &&
+            engine->activeMacro->anchors.empty() &&
+            ReplayEngine::runtimeAccuracyModeFor(engine->activeMacro->accuracyMode) != AccuracyMode::CBS;
+    }
+
+    void processInputOnly(bool shouldUse, std::function<void(int)> dispatch) {
+        if (!shouldUse) return;
+        int progress = static_cast<int>(m_gameState.m_currentProgress / 2);
+        bool prev = m_fields->macroInput;
+        m_fields->macroInput = true;
+        dispatch(progress);
+        m_fields->macroInput = prev;
+    }
+
     void dispatchImmediatePlaybackAction(int tick, int button, bool down, bool player2) {
         auto* engine = ReplayEngine::get();
         if (tick == engine->respawnTickIndex) {
@@ -731,6 +763,40 @@ class $modify(MacroEngineBaseLayer, GJBaseGameLayer) {
         }
     }
 
+    void dispatchInputOnlyTTRInputs(int progress) {
+        auto* engine = ReplayEngine::get();
+        auto* inputListPtr = engine->activeTTRInputs();
+        if (!inputListPtr) {
+            return;
+        }
+
+        auto& inputList = *inputListPtr;
+
+        while (engine->executeIndex < inputList.size()) {
+            auto const& input = inputList[engine->executeIndex];
+            if (input.tick > progress) {
+                break;
+            }
+
+            bool player2 = input.isPlayer2();
+            dispatchImmediatePlaybackAction(input.tick, input.actionType, input.isPressed(), player2);
+            ++engine->executeIndex;
+        }
+    }
+
+    void dispatchGDRInputsOnly(int progress) {
+        auto* engine = ReplayEngine::get();
+        auto& inputList = engine->activeMacro->inputs;
+
+        while (engine->executeIndex < inputList.size()) {
+            auto const& input = inputList[engine->executeIndex];
+            int inputTick = static_cast<int>(input.frame);
+            if (inputTick > progress) break;
+            dispatchImmediatePlaybackAction(inputTick, input.button, input.down, input.player2);
+            ++engine->executeIndex;
+        }
+    }
+
     void dispatchGDRInputs(int tick, int effectiveTick, int stepDelta) {
         auto* engine = ReplayEngine::get();
         auto& inputList = engine->activeMacro->inputs;
@@ -789,7 +855,7 @@ class $modify(MacroEngineBaseLayer, GJBaseGameLayer) {
         int effectiveTick = tick + engine->tickOffset;
         AccuracyMode playbackAccuracy = ReplayEngine::runtimeAccuracyModeFor(engine->activeMacroAccuracyMode());
 
-        if (playbackAccuracy != AccuracyMode::CBS) {
+        if (playbackAccuracy != AccuracyMode::CBS && !shouldUseInputOnlyTTRPlayback() && !shouldUseInputOnlyGDRPlayback()) {
             m_fields->macroInput = true;
             if (engine->ttrMode && engine->activeTTR) {
                 dispatchTTRInputs(tick, effectiveTick, stepDelta);
@@ -867,6 +933,10 @@ class $modify(MacroEngineBaseLayer, GJBaseGameLayer) {
             (executingCBS && engine->manualInputIgnoredActive() && !queuedSnapshot.empty());
         engine->cbsPlaybackProcessingQueue = executingCBS;
         GJBaseGameLayer::processQueuedButtons(dt, clearInputQueue);
+
+        processInputOnly(shouldUseInputOnlyTTRPlayback(), [&](int p) { dispatchInputOnlyTTRInputs(p); });
+        processInputOnly(shouldUseInputOnlyGDRPlayback(), [&](int p) { dispatchGDRInputsOnly(p); });
+
         m_fields->macroInput = previousMacroInput;
         engine->cbsPlaybackProcessingQueue = previousCbsPlaybackProcessingQueue;
         engine->cbsCaptureProcessingQueue = false;


### PR DESCRIPTION
Two fixes:
- Conversion no longer drops inputs (only consecutive duplicates are removed).
- Converted macros without anchors now use a simple input‑only playback.

Native macros are unaffected. Works fine with GDR2 -> TTR2/GDR conversions.

Before this change, converted macros (GDR2) failed; now they do not.
Tested with: Bloodbath, Thinking Space II, Acheron, The Lost Existence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined duplicate input detection during macro conversion to remove only consecutive transitions with matching properties.
  * Extended TTR and GDR run replay support with input-only mode handling when runtime accuracy conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->