### PR TITLE
fix macos + ttr3 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,10 +109,25 @@ function(patch_gd_imgui_cocos_backend backend_file)
         "auto static read = geode::utils::clipboard::read();"
         "auto static read = new std::string();"
     )
-    toastyreplay_replace_once_or_verify(
+    set(toastyreplay_clipboard_read_block [=[#if defined(GEODE_IS_WINDOWS)
+		*read = readClipboardText();
+#else
+		*read = geode::utils::clipboard::read();
+#endif]=])
+    toastyreplay_replace_if_present(
         backend_content
         "read = geode::utils::clipboard::read();"
+        "${toastyreplay_clipboard_read_block}"
+    )
+    toastyreplay_replace_if_present(
+        backend_content
         "*read = readClipboardText();"
+        "${toastyreplay_clipboard_read_block}"
+    )
+    toastyreplay_replace_once_or_verify(
+        backend_content
+        "${toastyreplay_clipboard_read_block}"
+        "${toastyreplay_clipboard_read_block}"
     )
     toastyreplay_replace_once_or_verify(
         backend_content

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2557,7 +2557,7 @@ void MenuInterface::drawReplayTab() {
             }
             if (convertClicked && canStartConversion) {
                 auto sourcePath = selectedForeign->path;
-                auto target = replayConvertTargetTTR ? toasty::conversion::ConversionTarget::TTR : toasty::conversion::ConversionTarget::GDR;
+                auto target = replayConvertTargetTTR ? toasty::conversion::ConversionTarget::TTR3 : toasty::conversion::ConversionTarget::GDR;
                 std::string requestedName = replayConvertNameBuffer;
                 std::string author = GJAccountManager::get() ? GJAccountManager::get()->m_username : "";
                 auto outputDirectory = getReplayDirectoryPath();


### PR DESCRIPTION
Fixes the red main build from #23: conversion enum rename + macOS ImGui-Cocos clipboard patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the conversion mode selection in the "Needs Conversion" UI to use the appropriate conversion target for replay conversions.

* **Refactor**
  * Improved clipboard handling logic in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->