### PR TITLE
Add search/pagination to lists, fix GDR2 conversion, and improve TTR3 warning

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -380,5 +380,7 @@
   "Your account has been restricted.": "Your account has been restricted.",
   "Your account is restricted from submitting issues.": "Your account is restricted from submitting issues.",
   "Your account is restricted from uploading macros.": "Your account is restricted from uploading macros.",
-  "~{cps} clicks/sec with fractional substeps": "~{cps} clicks/sec with fractional substeps"
+  "~{cps} clicks/sec with fractional substeps": "~{cps} clicks/sec with fractional substeps",
+  "Search...": "Search...",
+  "Page {current} / {total}": "Page {current} / {total}"
 }

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -354,5 +354,7 @@
     "Your account has been restricted.":  "Tu cuenta ha sido restringida.",
     "Your account is restricted from submitting issues.":  "Tu cuenta no puede enviar incidencias.",
     "Your account is restricted from uploading macros.":  "Tu cuenta no puede cargar macros.",
-    "~{cps} clicks/sec with fractional substeps":  "~{cps} clics/segundo con subpasos fraccionarios"
+    "~{cps} clicks/sec with fractional substeps":  "~{cps} clics/segundo con subpasos fraccionarios",
+    "Search...": "Buscar...",
+    "Page {current} / {total}": "Página {current} / {total}"
 }

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -354,5 +354,7 @@
   "Your account has been restricted.": "Ton compte a été restreint.",
   "Your account is restricted from submitting issues.": "Ton compte ne peut pas envoyer de signalements.",
   "Your account is restricted from uploading macros.": "Ton compte ne peut pas envoyer de macros.",
-  "~{cps} clicks/sec with fractional substeps": "~{cps} clics/sec avec sous-étapes fractionnaires"
+  "~{cps} clicks/sec with fractional substeps": "~{cps} clics/sec avec sous-étapes fractionnaires",
+  "Search...": "Rechercher...",
+  "Page {current} / {total}": "Page {current} / {total}"
 }

--- a/resources/lang/vi.json
+++ b/resources/lang/vi.json
@@ -380,5 +380,7 @@
   "Your account has been restricted.": "Tài khoản của bạn đã bị hạn chế.",
   "Your account is restricted from submitting issues.": "Tài khoản của bạn không thể gửi báo cáo.",
   "Your account is restricted from uploading macros.": "Tài khoản của bạn không thể tải lên macro.",
-  "~{cps} clicks/sec with fractional substeps": "~{cps} lần nhấp/giây với bước phụ phân số"
+  "~{cps} clicks/sec with fractional substeps": "~{cps} lần nhấp/giây với bước phụ phân số",
+  "Search...": "Tìm kiếm...",
+  "Page {current} / {total}": "Trang {current} / {total}"
 }

--- a/resources/lang/zh.json
+++ b/resources/lang/zh.json
@@ -380,5 +380,7 @@
   "Your account has been restricted.": "你的账号已被限制。",
   "Your account is restricted from submitting issues.": "你的账号不能提交问题。",
   "Your account is restricted from uploading macros.": "你的账号不能上传宏。",
-  "~{cps} clicks/sec with fractional substeps": "~{cps} 次点击/秒（含小数子步）"
+  "~{cps} clicks/sec with fractional substeps": "~{cps} 次点击/秒（含小数子步）",
+  "Search...": "搜索...",
+  "Page {current} / {total}": "第 {current} 页 / 共 {total} 页"
 }

--- a/src/conversion/macro_converter.cpp
+++ b/src/conversion/macro_converter.cpp
@@ -546,7 +546,6 @@ static void finishImport(ImportedReplay& replay) {
 
     std::stable_sort(replay.inputs.begin(), replay.inputs.end(), inputLess);
 
-    std::array<bool, 6> held = { false, false, false, false, false, false };
     std::vector<ImportedInput> normalized;
     normalized.reserve(replay.inputs.size());
     size_t removedDuplicates = 0;
@@ -554,12 +553,17 @@ static void finishImport(ImportedReplay& replay) {
     for (auto input : replay.inputs) {
         input.button = sanitizeButton(input.button);
         input.tick = static_cast<int64_t>(std::llround(std::max(0.0, input.time * replay.fps)));
-        size_t idx = (input.player2 ? 3u : 0u) + static_cast<size_t>(input.button - 1);
-        if (!input.swift && held[idx] == input.pressed) {
-            ++removedDuplicates;
-            continue;
+        
+        if (!normalized.empty()) {
+            auto const& last = normalized.back();
+            if (last.tick == input.tick &&
+                last.button == input.button &&
+                last.player2 == input.player2 &&
+                last.pressed == input.pressed) {
+                ++removedDuplicates;
+                continue;
+            }
         }
-        held[idx] = input.pressed;
         input.sequence = static_cast<uint64_t>(normalized.size());
         normalized.push_back(input);
     }
@@ -2328,19 +2332,23 @@ ConversionResult convertReplay(
         macro.levelInfo.name = imported->levelName.empty() ? outputName : imported->levelName;
         macro.levelInfo.id = imported->levelId;
         macro.framerate = result.fps;
-        macro.duration = outputDuration;
-        macro.accuracyMode = outputAccuracy;
+        macro.duration = imported->duration;
+        macro.accuracyMode = AccuracyMode::Vanilla;
         macro.platformerMode = imported->platformerMode;
         macro.hasPlatformerModeMetadata = true;
-        macro.anchors = imported->anchors;
-        macro.inputs.reserve(inputs.size());
-        for (auto const& input : inputs) {
+        macro.anchors = imported->anchors;  
+        macro.inputs.reserve(imported->inputs.size());
+
+        for (auto const& input : imported->inputs) {
+            double rawTick = input.time * result.fps;
+            int64_t tick = static_cast<int64_t>(std::llround(rawTick));
+            tick = std::clamp<int64_t>(tick, 0, std::numeric_limits<int32_t>::max());
             macro.inputs.emplace_back(
-                static_cast<int>(std::clamp<int64_t>(input.tick, 0, std::numeric_limits<int32_t>::max())),
+                static_cast<int>(tick),
                 input.button,
                 input.player2,
                 input.pressed,
-                useCbsTiming ? input.stepOffset : 0.0f
+                0.0f  
             );
         }
         auto bytes = macro.exportData(false);
@@ -2352,10 +2360,7 @@ ConversionResult convertReplay(
         result.ok = true;
         result.outputName = outputName;
         result.outputPath = outputPath;
-        std::ostringstream message;
-        message << "Converted " << result.inputCount << " inputs at " << result.fps
-                << " TPS to " << outputName << conversionTargetExtension(target);
-        result.message = message.str();
+        result.message = "Converted " + std::to_string(result.inputCount) + " inputs at " + std::to_string(result.fps) + " TPS to " + outputName + ".gdr";
         geode::log::info("[TR-CONV][I003] GDR/TTR2 conversion finished: out={} inputs={} fps={:.1f} cbs={}",
             toasty::pathToUtf8(result.outputPath), result.inputCount, result.fps, useCbsTiming);
     } catch (std::exception const& ex) {

--- a/src/conversion/macro_converter.hpp
+++ b/src/conversion/macro_converter.hpp
@@ -284,7 +284,8 @@ std::vector<ReplayFormat> supportedFormats();
 bool isForeignReplayExtension(std::filesystem::path const& path);
 inline constexpr char kTTR3BlockedWarning[] =
     "This macro format does not store enough timing information for frame-perfect TTR3 conversion. "
-    "Re-record the macro on ToastyReplay for guaranteed accuracy.";
+    "Re-record the macro on ToastyReplay for guaranteed accuracy. "
+    "Try converting it to GDR instead.";
 
 inline TTR3Eligibility inspectTTR3Eligibility(ReplayFormat format, TTR3InspectionFacts const& facts) {
     auto lossless = [] {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1892,9 +1892,44 @@ void MenuInterface::drawReplayTab() {
 
     Widgets::SectionHeader("Usable Replays", theme);
 
+    ImGui::SetNextItemWidth(-1);
+    if (ImGui::InputTextWithHint("##replaySearch", trString("Search...").c_str(), replaySearchBuffer, sizeof(replaySearchBuffer))) {
+        replayCurrentPage = 0; 
+    }
+    ImGui::Dummy(ImVec2(0, 4));
+
+    std::vector<std::string> filteredMacros;
+    std::string searchLower = replaySearchBuffer;
+    std::transform(searchLower.begin(), searchLower.end(), searchLower.begin(), ::tolower);
+    for (const auto& macro : engine->storedMacros) {
+        std::string macroLower = macro;
+        std::transform(macroLower.begin(), macroLower.end(), macroLower.begin(), ::tolower);
+        if (searchLower.empty() || macroLower.find(searchLower) != std::string::npos) {
+            filteredMacros.push_back(macro);
+        }
+    }
+
+    int totalMacros = (int)filteredMacros.size();
+    int totalPages = (totalMacros + replayPageSize - 1) / replayPageSize;
+    if (totalPages == 0) totalPages = 1;
+    if (replayCurrentPage >= totalPages) replayCurrentPage = totalPages - 1;
+    if (replayCurrentPage < 0) replayCurrentPage = 0;
+
+    ImGui::BeginGroup();
+    if (ImGui::ArrowButton("##prevPageReplay", ImGuiDir_Up) && replayCurrentPage > 0) replayCurrentPage--;
+    ImGui::SameLine();
+    auto pageText = trFormat("Page {current} / {total}",
+        fmt::arg("current", replayCurrentPage + 1),
+        fmt::arg("total", totalPages));
+    ImGui::TextUnformatted(pageText.c_str());
+    ImGui::SameLine();
+    if (ImGui::ArrowButton("##nextPageReplay", ImGuiDir_Down) && replayCurrentPage < totalPages - 1) replayCurrentPage++;
+    ImGui::EndGroup();
+    ImGui::Dummy(ImVec2(0, 8));
+
     float listPadY = 8.0f;
     float listPadX = 10.0f;
-    float listH = std::max(80.0f, std::min(200.0f, (float)engine->storedMacros.size() * 28.0f + listPadY * 2.0f));
+    float listH = std::max(80.0f, std::min(200.0f, (float)filteredMacros.size() * 28.0f + listPadY * 2.0f));
     ImVec2 listPos = ImGui::GetCursorScreenPos();
     float listW = ImGui::GetContentRegionAvail().x;
     drawSolidRect(ImGui::GetWindowDrawList(), listPos, ImVec2(listPos.x + listW, listPos.y + listH), theme.cornerRadius, theme, 0.55f);
@@ -1906,7 +1941,7 @@ void MenuInterface::drawReplayTab() {
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + listPadX);
     ImGui::Dummy(ImVec2(0, listPadY));
 
-    if (engine->storedMacros.empty()) {
+    if (filteredMacros.empty()) {  
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + listPadX);
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.4f));
         imguiTextTr("No usable replays");
@@ -1920,8 +1955,10 @@ void MenuInterface::drawReplayTab() {
         replayLoadReadyTime = ImGui::GetTime() + static_cast<double>(ImGui::GetIO().MouseDoubleClickTime) + 0.02;
     };
 
-    auto macroListCopy = engine->storedMacros;
-    for (const auto& macroName : macroListCopy) {
+    int startIdx = replayCurrentPage * replayPageSize;
+    int endIdx = std::min(startIdx + replayPageSize, totalMacros);
+    for (int i = startIdx; i < endIdx; ++i) {
+        const std::string& macroName = filteredMacros[i];
         bool isSelected = (engine->hasMacro() && engine->engineMode != MODE_CAPTURE && engine->getMacroName() == macroName);
         bool isIncompatible = engine->incompatibleMacros.count(macroName) > 0;
         bool isCBS = engine->cbsMacros.count(macroName) > 0;
@@ -2095,7 +2132,7 @@ void MenuInterface::drawReplayTab() {
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor();
 
-    if (replayLoadPending) {
+   if (replayLoadPending) {
         if (engine->engineMode == MODE_CAPTURE) {
             replayLoadPending = false;
         } else if (ImGui::GetTime() >= replayLoadReadyTime) {
@@ -2409,97 +2446,134 @@ void MenuInterface::drawReplayTab() {
         replayConversionsExpanded = !replayConversionsExpanded;
     }
 
-    if (replayConversionsExpanded) {
+if (replayConversionsExpanded) {
     ImGui::Dummy(ImVec2(0, 2));
     Widgets::SectionHeader("Needs Conversion", theme);
 
-    float convertListH = std::max(60.0f, std::min(150.0f, (float)engine->foreignReplays.size() * 28.0f + listPadY * 2.0f));
-    ImVec2 convertListPos = ImGui::GetCursorScreenPos();
-    float convertListW = ImGui::GetContentRegionAvail().x;
-    drawSolidRect(ImGui::GetWindowDrawList(), convertListPos, ImVec2(convertListPos.x + convertListW, convertListPos.y + convertListH), theme.cornerRadius, theme, 0.42f);
+    ImGui::SetNextItemWidth(-1);
+    if (ImGui::InputTextWithHint("##foreignSearch", trString("Search...").c_str(), foreignSearchBuffer, sizeof(foreignSearchBuffer))) {
+        foreignCurrentPage = 0;
+    }
+    ImGui::Dummy(ImVec2(0, 4));
+
+    std::vector<toasty::conversion::DetectedReplay> filteredForeign;
+    std::string searchLower = foreignSearchBuffer;
+    std::transform(searchLower.begin(), searchLower.end(), searchLower.begin(), ::tolower);
+    for (const auto& entry : engine->foreignReplays) {
+        std::string nameLower = entry.filename;
+        std::transform(nameLower.begin(), nameLower.end(), nameLower.begin(), ::tolower);
+        if (searchLower.empty() || nameLower.find(searchLower) != std::string::npos) {
+            filteredForeign.push_back(entry);
+        }
+    }
+
+    int totalForeign = (int)filteredForeign.size();
+    int totalForeignPages = (totalForeign + replayPageSizeConversion - 1) / replayPageSizeConversion;
+    if (totalForeignPages == 0) totalForeignPages = 1;
+    if (foreignCurrentPage >= totalForeignPages) foreignCurrentPage = totalForeignPages - 1;
+    if (foreignCurrentPage < 0) foreignCurrentPage = 0;
+
+    ImGui::BeginGroup();
+    if (ImGui::ArrowButton("##prevForeignPage", ImGuiDir_Up) && foreignCurrentPage > 0) foreignCurrentPage--;
+    ImGui::SameLine();
+    auto foreignPageText = trFormat("Page {current} / {total}",
+        fmt::arg("current", foreignCurrentPage + 1),
+        fmt::arg("total", totalForeignPages));
+    ImGui::TextUnformatted(foreignPageText.c_str());
+    ImGui::SameLine();
+    if (ImGui::ArrowButton("##nextForeignPage", ImGuiDir_Down) && foreignCurrentPage < totalForeignPages - 1) foreignCurrentPage++;
+    ImGui::EndGroup();
+    ImGui::Dummy(ImVec2(0, 8));
+
+    float foreignPadY = 8.0f;
+    float foreignPadX = 10.0f;
+    float listH = std::max(80.0f, std::min(150.0f, (float)filteredForeign.size() * 28.0f + foreignPadY * 2.0f));
+    ImVec2 listPos = ImGui::GetCursorScreenPos();
+    float listW = ImGui::GetContentRegionAvail().x;
+    drawSolidRect(ImGui::GetWindowDrawList(), listPos, ImVec2(listPos.x + listW, listPos.y + listH), theme.cornerRadius, theme, 0.42f);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(0, 0, 0, 0));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 12.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
-    ImGui::BeginChild("##ForeignMacroList", ImVec2(-1, convertListH), false);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + listPadX);
-    ImGui::Dummy(ImVec2(0, listPadY));
+    ImGui::BeginChild("##ForeignMacroList", ImVec2(-1, listH), false);
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + foreignPadX);
+    ImGui::Dummy(ImVec2(0, foreignPadY));
 
-    if (engine->foreignReplays.empty()) {
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + listPadX);
+    if (filteredForeign.empty()) {
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + foreignPadX);
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 0.4f));
         imguiTextTr("No old macros found");
         ImGui::PopStyleColor();
-    }
+    } else {
+        int start = foreignCurrentPage * replayPageSizeConversion;
+        int end = std::min(start + replayPageSizeConversion, totalForeign);
+        for (int idx = start; idx < end; ++idx) {
+            const auto& entry = filteredForeign[idx];
+            auto pathKey = toasty::conversion::normalizedPathKey(entry.path);
+            bool selected = replayConvertSelectedPath == pathKey;
+            bool converted = entry.converted || engine->convertedForeignReplaySources.count(pathKey) > 0;
+            bool canConvert = entry.supported && !replayConvertRunning;
+            std::string statusText = converted ? "Converted" : (entry.supported ? "Convert" : (entry.recognized ? "Unsupported" : "Error"));
+            ImVec4 statusColor = converted
+                ? ImVec4(0.3f, 1.0f, 0.45f, 1.0f)
+                : (entry.supported ? theme.getAccent() : ImVec4(1.0f, 0.35f, 0.28f, 1.0f));
 
-    for (auto const& entry : engine->foreignReplays) {
-        auto pathKey = toasty::conversion::normalizedPathKey(entry.path);
-        bool selected = replayConvertSelectedPath == pathKey;
-        bool converted = entry.converted || engine->convertedForeignReplaySources.count(pathKey) > 0;
-        bool canConvert = entry.supported && !replayConvertRunning;
-        std::string statusText = converted ? "Converted" : (entry.supported ? "Convert" : (entry.recognized ? "Unsupported" : "Error"));
-        ImVec4 statusColor = converted
-            ? ImVec4(0.3f, 1.0f, 0.45f, 1.0f)
-            : (entry.supported ? theme.getAccent() : ImVec4(1.0f, 0.35f, 0.28f, 1.0f));
-
-        ImGui::PushID(pathKey.c_str());
-        float rowH = ImGui::GetTextLineHeight() + 8.0f;
-        float fullRowW = ImGui::GetContentRegionAvail().x;
-        ImVec2 rowStart = ImGui::GetCursorScreenPos();
-        bool rowActivated = ImGui::Selectable("##foreignrow", selected, ImGuiSelectableFlags_AllowOverlap, ImVec2(fullRowW, rowH));
-        if (ImGui::IsItemHovered() && !entry.detail.empty()) {
-            ImGui::SetTooltip("%s", entry.detail.c_str());
-        }
-        if (rowActivated) {
-            replayConvertSelectedPath = pathKey;
-            std::strncpy(replayConvertNameBuffer, entry.stem.c_str(), sizeof(replayConvertNameBuffer) - 1);
-            replayConvertNameBuffer[sizeof(replayConvertNameBuffer) - 1] = '\0';
-            replayConvertTargetTTR = true;
-            replayConvertStatus.clear();
-            replayConvertWarnings.clear();
-            replayConvertStatusOk = false;
-            replayConvertShowStandaloneStatus = false;
-        }
-
-        std::string nameLabel = entry.filename.empty() ? entry.stem : entry.filename;
-        std::string formatLabel = toasty::conversion::formatDisplayName(entry.format);
-        float statusW = ImGui::CalcTextSize(statusText.c_str()).x + 10.0f;
-        float formatW = ImGui::CalcTextSize(formatLabel.c_str()).x + 12.0f;
-        float maxNameW = std::max(40.0f, fullRowW - statusW - formatW - listPadX * 2.0f - 22.0f);
-        if (ImGui::CalcTextSize(nameLabel.c_str()).x > maxNameW) {
-            while (!nameLabel.empty() && ImGui::CalcTextSize((nameLabel + "...").c_str()).x > maxNameW) {
-                nameLabel.pop_back();
+            ImGui::PushID(pathKey.c_str());
+            float rowH = ImGui::GetTextLineHeight() + 8.0f;
+            float fullRowW = ImGui::GetContentRegionAvail().x;
+            ImVec2 rowStart = ImGui::GetCursorScreenPos();
+            bool rowActivated = ImGui::Selectable("##foreignrow", selected, ImGuiSelectableFlags_AllowOverlap, ImVec2(fullRowW, rowH));
+            if (ImGui::IsItemHovered() && !entry.detail.empty()) {
+                ImGui::SetTooltip("%s", entry.detail.c_str());
             }
-            nameLabel += "...";
+            if (rowActivated) {
+                replayConvertSelectedPath = pathKey;
+                std::strncpy(replayConvertNameBuffer, entry.stem.c_str(), sizeof(replayConvertNameBuffer) - 1);
+                replayConvertNameBuffer[sizeof(replayConvertNameBuffer) - 1] = '\0';
+                replayConvertTargetTTR = true;
+                replayConvertStatus.clear();
+                replayConvertWarnings.clear();
+                replayConvertStatusOk = false;
+                replayConvertShowStandaloneStatus = false;
+            }
+
+            std::string nameLabel = entry.filename.empty() ? entry.stem : entry.filename;
+            std::string formatLabel = toasty::conversion::formatDisplayName(entry.format);
+            float maxNameW = std::max(40.0f, fullRowW - ImGui::CalcTextSize(statusText.c_str()).x - 10.0f - ImGui::CalcTextSize(formatLabel.c_str()).x - 12.0f - foreignPadX * 2.0f - 22.0f);
+            if (ImGui::CalcTextSize(nameLabel.c_str()).x > maxNameW) {
+                while (!nameLabel.empty() && ImGui::CalcTextSize((nameLabel + "...").c_str()).x > maxNameW)
+                    nameLabel.pop_back();
+                nameLabel += "...";
+            }
+
+            float itemMinY = rowStart.y;
+            float itemH = rowH;
+            ImGui::GetWindowDrawList()->AddText(
+                ImVec2(rowStart.x + foreignPadX, itemMinY + (itemH - ImGui::GetTextLineHeight()) * 0.5f),
+                entry.supported ? theme.getTextU32() : toU32(ImVec4(1.0f, 1.0f, 1.0f, 0.55f)),
+                nameLabel.c_str()
+            );
+
+            float tagX = rowStart.x + fullRowW - foreignPadX;
+            ImVec2 statusSize = ImGui::CalcTextSize(statusText.c_str());
+            tagX -= statusSize.x;
+            ImGui::GetWindowDrawList()->AddText(
+                ImVec2(tagX, itemMinY + (itemH - statusSize.y) * 0.5f),
+                toU32(statusColor),
+                statusText.c_str()
+            );
+            ImVec2 formatSize = ImGui::CalcTextSize(formatLabel.c_str());
+            tagX -= formatSize.x + 12.0f;
+            ImGui::GetWindowDrawList()->AddText(
+                ImVec2(tagX, itemMinY + (itemH - formatSize.y) * 0.5f),
+                toU32(ImVec4(1.0f, 0.85f, 0.35f, entry.recognized ? 1.0f : 0.55f)),
+                formatLabel.c_str()
+            );
+
+            if (rowActivated && canConvert && ImGui::IsMouseDoubleClicked(0)) {
+                replayConvertStatus.clear();
+            }
+            ImGui::PopID();
         }
-
-        float itemMinY = rowStart.y;
-        float itemH = rowH;
-        ImGui::GetWindowDrawList()->AddText(
-            ImVec2(rowStart.x + listPadX, itemMinY + (itemH - ImGui::GetTextLineHeight()) * 0.5f),
-            entry.supported ? theme.getTextU32() : toU32(ImVec4(1.0f, 1.0f, 1.0f, 0.55f)),
-            nameLabel.c_str()
-        );
-
-        float tagX = rowStart.x + fullRowW - listPadX;
-        ImVec2 statusSize = ImGui::CalcTextSize(statusText.c_str());
-        tagX -= statusSize.x;
-        ImGui::GetWindowDrawList()->AddText(
-            ImVec2(tagX, itemMinY + (itemH - statusSize.y) * 0.5f),
-            toU32(statusColor),
-            statusText.c_str()
-        );
-        ImVec2 formatSize = ImGui::CalcTextSize(formatLabel.c_str());
-        tagX -= formatSize.x + 12.0f;
-        ImGui::GetWindowDrawList()->AddText(
-            ImVec2(tagX, itemMinY + (itemH - formatSize.y) * 0.5f),
-            toU32(ImVec4(1.0f, 0.85f, 0.35f, entry.recognized ? 1.0f : 0.55f)),
-            formatLabel.c_str()
-        );
-
-        if (rowActivated && canConvert && ImGui::IsMouseDoubleClicked(0)) {
-            replayConvertStatus.clear();
-        }
-        ImGui::PopID();
     }
 
     ImGui::EndChild();

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -178,6 +178,12 @@ public:
     char backupVideoArgsBuf[256] = "colorspace=all=bt709:iall=bt470bg:fast=1";
     char backupAudioArgsBuf[256] = "";
     char backupSecondsAfterBuf[16] = "3";
+    char replaySearchBuffer[64] = "";
+    int replayCurrentPage = 0;
+    static constexpr int replayPageSize = 6;
+    static constexpr int replayPageSizeConversion = 4;
+    char foreignSearchBuffer[64] = "";
+    int foreignCurrentPage = 0;
 
     ImVec2 windowPos = ImVec2(-1, -1);
     bool windowPosInitialized = false;


### PR DESCRIPTION
What's changed

UI improvements
- Added search/filter input to "Usable Replays" and "Needs Conversion" lists.
- Added pagination controls (up/down arrows) to both lists, eliminating scroll issues.
- Each list has its own page state and search buffer, saved between sessions.
- Page size: 6 for usable replays, 4 for conversion candidates.

GDR2 conversion fix
- Restored original input deduplication logic (compare with last input instead of using held[]).
- Fixed tick calculation using llround for accurate GDR output.
- Conversion now preserves held button states correctly.

TTR3 conversion warning
- Improved the blocked message to suggest using GDR when TTR3 conversion is not available.
- Users will see: "Try converting it to GDR instead."

Why
- Better user experience when many macros are stored.
- GDR2 macros now convert and play back with correct hold behavior.
- Clearer guidance when TTR3 conversion is not lossless.
<img width="772" height="852" alt="image" src="https://github.com/user-attachments/assets/8e0f67cb-f628-40c0-bcab-0958bf9fada4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text search for saved macros and for the “Needs Conversion” list, with case-insensitive filtering.
  * Updated pagination to recalculate and clamp pages based on filtered results.
* **Localization**
  * Added translated UI strings for the search label and pagination (“Page {current} / {total}”) in English, Spanish, French, Vietnamese, and Chinese.
* **Conversion Updates**
  * Improved conversion handling by normalizing/deduplicating imported inputs.
  * Updated guidance/warning text to suggest trying GDR conversion instead.
* **UI Improvements**
  * Empty state now reflects the filtered results list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->